### PR TITLE
fix: update examples highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Whilst Enabling clean and reliable handling of cases where required dependencies
 aren't available.
 
 #### Installation
-`go get github.com/LS6-Events/healthcheck`
+```bash
+go get github.com/LS6-Events/healthcheck
+```
 
 #### Example
 ```go

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ aren't available.
 `go get github.com/LS6-Events/healthcheck`
 
 #### Example
-```
+```go
 aHealthManager, err = healthcheck.New(time.second, time.minute)
 if err != nil {
     // handle error


### PR DESCRIPTION
This PR updates the example markdown to use go and bash highlighting