### PR TITLE
chore: fix RabbitMQ Testcontainer

### DIFF
--- a/checks/rabbitmq_test.go
+++ b/checks/rabbitmq_test.go
@@ -56,7 +56,7 @@ func TestRabbitmqHealthCheck(t *testing.T) {
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "rabbitmq:alpine",
 			ExposedPorts: []string{fmt.Sprint(rmqPort)},
-			WaitingFor:   wait.ForAll(wait.ForListeningPort(cntrPort), wait.ForLog("Server startup complete; 3 plugins started.")),
+			WaitingFor:   wait.ForAll(wait.ForListeningPort(cntrPort), wait.ForLog("Server startup complete;.*").AsRegexp()),
 			Env: map[string]string{
 				"RABBITMQ_DEFAULT_USER": rmqUser,
 				"RABBITMQ_DEFAULT_PASS": rmqPass,


### PR DESCRIPTION
This PR fixes the issue where all cloud runs of the CI pipelines fail. This is due to the fact that the Testcontainer was waiting for `Server startup complete; 3 plugins started.` to be logged when `Server startup complete; 4 plugins started.`  was actually being logged. This was causing the testing context to timeout causing the tests to fail.